### PR TITLE
add DCTL coded error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Usage: dc-template-linter [options] <template.json> [...]
 	pretty-print template json
   -tolerate string
 	non-zero return loglevel treshold: any error warn info debug none (default "info")
+  -ttl uint
+	-inplace ttl fix value to be used when template ttl is zero or invalid
   -version
 	output version information and exit
 Warning. -inplace and -pretty will remove zero priority MX and SRV fields
+You can find long DCTL explanations in wiki
+e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1001
 ```

--- a/internal/dctl.go
+++ b/internal/dctl.go
@@ -1,0 +1,123 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog"
+)
+
+// DCTL codes type
+type DCTL uint16
+
+// DCTL code reservations
+// 0000         unused
+// 0001 - 0999  operating system and library errors
+// 1000 - 3999  domain connect specific messages
+// 5000 - 5200  cloudflare messages
+const (
+	DCTL0001 DCTL = 1
+	DCTL0002 DCTL = 2
+	DCTL0003 DCTL = 3
+	DCTL0004 DCTL = 4
+	DCTL0005 DCTL = 5
+	DCTL0006 DCTL = 6
+	DCTL0007 DCTL = 7
+	DCTL0008 DCTL = 8
+	DCTL0009 DCTL = 9
+
+	DCTL1000 DCTL = 1000
+	DCTL1001 DCTL = 1001
+	DCTL1002 DCTL = 1002
+	DCTL1003 DCTL = 1003
+	DCTL1004 DCTL = 1004
+	DCTL1005 DCTL = 1005
+	DCTL1006 DCTL = 1006
+	DCTL1007 DCTL = 1007
+	DCTL1008 DCTL = 1008
+	DCTL1009 DCTL = 1009
+	DCTL1010 DCTL = 1010
+	DCTL1011 DCTL = 1011
+	DCTL1012 DCTL = 1012
+	DCTL1013 DCTL = 1013
+	DCTL1014 DCTL = 1014
+	DCTL1015 DCTL = 1015
+	DCTL1016 DCTL = 1016
+	DCTL1017 DCTL = 1017
+	DCTL1018 DCTL = 1018
+	DCTL1019 DCTL = 1019
+	DCTL1020 DCTL = 1020
+	DCTL1021 DCTL = 1021
+
+	DCTL5000 DCTL = 5000
+	DCTL5001 DCTL = 5001
+	DCTL5002 DCTL = 5002
+	DCTL5003 DCTL = 5003
+	DCTL5004 DCTL = 5004
+	DCTL5005 DCTL = 5005
+	DCTL5006 DCTL = 5006
+	DCTL5007 DCTL = 5007
+	DCTL5008 DCTL = 5008
+	DCTL5009 DCTL = 5009
+	DCTL5010 DCTL = 5010
+	DCTL5011 DCTL = 5011
+)
+
+// DCTL descriptions
+var dctlToString = map[DCTL]string{
+	// operating system and library errors
+	DCTL0001: "cannot open file",
+	DCTL0002: "invalid loglevel",
+	DCTL0003: "json error",
+	DCTL0004: "write failed",
+	DCTL0005: "could not create temporary file",
+	DCTL0006: "file move failed",
+	DCTL0007: "struct json tag missing",
+	DCTL0008: "required field is missing",
+	DCTL0009: "unnecessary field found",
+
+	// domain connect specific messages
+	DCTL1000: "ttl value exceeds maximum",
+	DCTL1001: "do not quote an integer",
+	DCTL1002: "id contains invalid characters",
+	DCTL1003: "file name does not use required pattern",
+	DCTL1004: "duplicate provierId + serviceId detected",
+	DCTL1005: "template field validation",
+	DCTL1006: "use of negative version number",
+	DCTL1007: "shared flag is deprecated, use sharedProviderName",
+	DCTL1008: "sharedProviderName is in use without 'shared' compatibility",
+	DCTL1009: "variable in invalid context",
+	DCTL1010: "logo check failed",
+	DCTL1011: "CNAME cannot be mixed with other record types",
+	DCTL1012: "record host must not be @ when template hostRequired is false",
+	DCTL1013: "key must not be empty",
+	DCTL1014: "use SPFM instead of bare SPF record",
+	DCTL1015: "invalid value",
+	DCTL1016: "unexpeceted record type",
+	DCTL1017: "spfRules contain invalid data",
+	DCTL1018: "spfRules contain duplicate fields",
+	DCTL1019: "variable contains invalid character",
+	DCTL1020: "variable is not terminated",
+	DCTL1021: "missing from iana definitions",
+
+	// cloudflare messages
+	DCTL5000: "syncBlock is not supported",
+	DCTL5001: "syncPubKeyDomain is required",
+	DCTL5002: "sharedServiceName is not supported",
+	DCTL5003: "syncRedirectDomain is not supported",
+	DCTL5004: "multiInstance is not supported",
+	DCTL5005: "warnPhishing is omitted",
+	DCTL5006: "hostRequired is not supported",
+	DCTL5007: "domains must use Cloudflares CNAME flattening setting",
+	DCTL5008: "conflict matching is not supported",
+	DCTL5009: "APEXCNAME is not supported",
+	DCTL5010: "zero ttl is not honoured",
+	DCTL5011: "essential is not supported",
+}
+
+func (dctl DCTL) MarshalZerologObject(e *zerolog.Event) {
+	description, ok := dctlToString[dctl]
+	if !ok {
+		description = "invalid DCTL code"
+	}
+	e.Str("code", fmt.Sprintf("DCTL%04d", dctl)).Str("dctl_note", description)
+}

--- a/internal/json.go
+++ b/internal/json.go
@@ -100,7 +100,7 @@ func (sint *SINT) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	exitVal = exitvals.CheckInfo
-	smuggledLog.Info().Str("value", s).Msg("do not quote an integer, it makes it string")
+	smuggledLog.Info().Str("value", s).EmbedObject(DCTL1001).Msg("")
 	*sint = SINT(i)
 	return nil
 }

--- a/internal/zerolog.go
+++ b/internal/zerolog.go
@@ -8,7 +8,7 @@ import (
 func SetLoglevel(loglevel string) {
 	level, err := zerolog.ParseLevel(loglevel)
 	if err != nil {
-		log.Fatal().Err(err).Msg("invalid loglevel")
+		log.Fatal().Err(err).EmbedObject(DCTL0002).Msg("")
 	}
 	zerolog.SetGlobalLevel(level)
 }

--- a/libdctlint/templatevar.go
+++ b/libdctlint/templatevar.go
@@ -32,14 +32,14 @@ func checkSingleString(input string, rlog zerolog.Logger) exitvals.CheckSeverity
 		}
 		if withInVar {
 			if !(('0' <= c && '9' >= c) || ('a' <= c && 'z' >= c) || ('A' <= c && 'Z' >= c) || c == '_' || c == '-') {
-				rlog.Warn().Str("invalid", input).Msg("invalid character found in variable string")
+				rlog.Warn().Str("invalid", input).EmbedObject(internal.DCTL1019).Msg("")
 				return exitvals.CheckWarn
 			}
 		}
 	}
 
 	if withInVar {
-		rlog.Error().Str("invalid", input).Msg("variable string is not terminated")
+		rlog.Error().Str("invalid", input).EmbedObject(internal.DCTL1020).Msg("")
 		return exitvals.CheckError
 	}
 

--- a/libdctlint/underscores.go
+++ b/libdctlint/underscores.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/Domain-Connect/dc-template-linter/exitvals"
+	"github.com/Domain-Connect/dc-template-linter/internal"
 
 	"golang.org/x/exp/slices"
 )
@@ -87,7 +88,7 @@ var rfc8552 = map[string][]uint16{
 }
 
 func (conf *Conf) checkUnderscoreNames(rrtype, host string) exitvals.CheckSeverity {
-	rlog := conf.tlog.With().Str("type", rrtype).Str("link", "https://www.iana.org/assignments/dns-parameters/dns-parameters.txt").Logger()
+	rlog := conf.tlog.With().Str("type", rrtype).Logger()
 	exitVal := exitvals.CheckOK
 
 	for _, elem := range strings.Split(host, ".") {
@@ -96,20 +97,20 @@ func (conf *Conf) checkUnderscoreNames(rrtype, host string) exitvals.CheckSeveri
 		}
 		okTypes, ok := rfc8552[strings.ToLower(elem)]
 		if !ok {
-			rlog.Debug().Str("host", elem).Msg("global definition does not define this underscore host")
+			rlog.Debug().Str("host", elem).EmbedObject(internal.DCTL1021).Msg("")
 			exitVal |= exitvals.CheckDebug
 			continue
 		}
 
 		templateType, ok := recordToType[strings.ToUpper(rrtype)]
 		if !ok {
-			rlog.Info().Str("host", elem).Msg("global definition does not have this host and type pair")
+			rlog.Info().Str("host", elem).EmbedObject(internal.DCTL1021).Msg("")
 			exitVal |= exitvals.CheckInfo
 			continue
 		}
 
 		if !slices.Contains(append([]uint16{TypeNS, TypeCNAME}, okTypes...), templateType) {
-			rlog.Info().Str("host", elem).Msg("global definition does not have this host and type pair")
+			rlog.Info().Str("host", elem).EmbedObject(internal.DCTL1021).Msg("")
 			exitVal |= exitvals.CheckInfo
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] <template.json> [...]\n", os.Args[0])
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "Warning. -inplace and -pretty will remove zero priority MX and SRV fields\n")
+		fmt.Fprintf(os.Stderr, "You can find long DCTL explanations in wiki\n")
+		fmt.Fprintf(os.Stderr, "e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1001\n")
 	}
 	checkLogos := flag.Bool("logos", false, "check logo urls are reachable (requires network)")
 	cloudflare := flag.Bool("cloudflare", false, "use Cloudflare specific template rules")
@@ -65,7 +67,7 @@ func main() {
 	exitVal := exitvals.CheckOK
 
 	if libdctlint.MaxTTL < *ttl {
-		log.Fatal().Uint("ttl", *ttl).Uint("max", libdctlint.MaxTTL).Msg("ttl value exceeds maximum")
+		log.Fatal().Uint("ttl", *ttl).Uint("max", libdctlint.MaxTTL).EmbedObject(internal.DCTL1000).Msg("")
 	}
 
 	conf := libdctlint.NewConf().
@@ -87,7 +89,7 @@ func main() {
 			conf.SetFilename(arg)
 			f, err := os.Open(arg)
 			if err != nil {
-				log.Error().Err(err).Msg("cannot open file")
+				log.Error().Err(err).EmbedObject(internal.DCTL0001).Msg("")
 				exitVal = exitvals.CheckError
 				continue
 			}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const dcTemplateLinterVersion uint = 50
+const dcTemplateLinterVersion uint = 53


### PR DESCRIPTION
Idea of having coded error messages was discussed in the pull request. Point of these codes is to have a well specified location where long explanations about errors can be added.  Errors from the lint tooling are expected to be brief while the supporting wiki pages need to explain in as much detail as possible what is wrong in the input, and how to fix it.

The idea is taken from ShellCheck that has done the same so well that imitators are inevitable.

Wiki pages: https://github.com/Domain-Connect/dc-template-linter/wiki

Reference: https://github.com/Domain-Connect/dc-template-linter/pull/8#discussion_r1589941877
Reference: https://www.shellcheck.net/wiki/Home
cc: @pawel-kow 