### PR TITLE
spec: allow number types to be ints, strings, and/or variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Usage: dc-template-linter [options] <template.json> [...]
 	output version information and exit
 Warning. -inplace and -pretty will remove zero priority MX and SRV fields
 You can find long DCTL explanations in wiki
-e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1001
+e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1003
 ```

--- a/internal/dctl.go
+++ b/internal/dctl.go
@@ -78,7 +78,7 @@ var dctlToString = map[DCTL]string{
 
 	// domain connect specific messages
 	DCTL1000: "ttl value exceeds maximum",
-	DCTL1001: "do not quote an integer",
+	DCTL1001: "<not in use after string-interger-variable values>",
 	DCTL1002: "id contains invalid characters",
 	DCTL1003: "file name does not use required pattern",
 	DCTL1004: "duplicate provierId + serviceId detected",

--- a/internal/json.go
+++ b/internal/json.go
@@ -11,7 +11,7 @@ type Template struct {
 	ProviderName        string  `json:"providerName" validate:"required,min=1,max=64"`
 	ServiceID           string  `json:"serviceId" validate:"required,min=1,max=64"`
 	ServiceName         string  `json:"serviceName" validate:"required,min=1,max=255"`
-	Version             SINT    `json:"version,omitempty"`
+	Version             uint    `json:"version,omitempty"`
 	Logo                string  `json:"logoUrl,omitempty"`
 	Description         string  `json:"description,omitempty"`
 	VariableDescription string  `json:"variableDescription,omitempty"`
@@ -74,16 +74,6 @@ func (sint *SINT) MarshalJSON() ([]byte, error) {
 	}
 	quoted := fmt.Sprintf("\"%s\"", *sint)
 	return []byte(quoted), nil
-}
-
-func (sint *SINT) Inc() {
-	i, err := strconv.Atoi(string(*sint))
-	if err != nil {
-		return
-	}
-	i++
-	s := fmt.Sprintf("%d", i)
-	*sint = SINT(s)
 }
 
 func (sint *SINT) Uint32() (uint32, bool) {

--- a/libdctlint/config.go
+++ b/libdctlint/config.go
@@ -16,7 +16,7 @@ type Conf struct {
 	inplace     bool
 	increment   bool
 	prettyPrint bool
-	ttl         uint
+	ttl         uint32
 }
 
 // NewConf will create template check configuration.
@@ -61,7 +61,7 @@ func (c *Conf) SetPrettyPrint(b bool) *Conf {
 	return c
 }
 
-func (c *Conf) SetTTL(t uint) *Conf {
+func (c *Conf) SetTTL(t uint32) *Conf {
 	c.ttl = t
 	return c
 }

--- a/libdctlint/lib.go
+++ b/libdctlint/lib.go
@@ -32,7 +32,6 @@ const (
 // outside of this project.
 func (conf *Conf) GetAndCheckTemplate(f *bufio.Reader) (internal.Template, exitvals.CheckSeverity) {
 	conf.SetLogger(log.With().Str("template", conf.fileName).Logger())
-	internal.SetLogger(conf.tlog)
 	conf.tlog.Debug().Msg("starting template check")
 
 	// Decode json
@@ -40,12 +39,11 @@ func (conf *Conf) GetAndCheckTemplate(f *bufio.Reader) (internal.Template, exitv
 	decoder.DisallowUnknownFields()
 	var template internal.Template
 	err := decoder.Decode(&template)
-	exitVal := internal.GetUnmarshalStatus()
 	if err != nil {
-		conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("")
+		conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("a")
 		return template, exitvals.CheckFatal
 	}
-	exitVal |= conf.checkTemplate(template)
+	exitVal := conf.checkTemplate(template)
 	return template, exitVal
 }
 
@@ -101,7 +99,7 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 	}
 
 	// Field checks provided by this file
-	if template.Version < 0 {
+	if len(template.Version) == 0 {
 		conf.tlog.Info().EmbedObject(internal.DCTL1006).Msg("")
 		exitVal |= exitvals.CheckInfo
 	}
@@ -151,12 +149,12 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 	// Pretty printing and/or inplace write output
 	if conf.prettyPrint || conf.inplace {
 		if conf.increment {
-			template.Version++
+			template.Version.Inc()
 		}
 		// Convert to json
 		marshaled, err := json.Marshal(template)
 		if err != nil {
-			conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("")
+			conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("b")
 			return exitVal | exitvals.CheckError
 		}
 
@@ -164,7 +162,7 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 		var out bytes.Buffer
 		err = json.Indent(&out, marshaled, "", "    ")
 		if err != nil {
-			conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("")
+			conf.tlog.Error().Err(err).EmbedObject(internal.DCTL0003).Msg("c")
 			return exitVal | exitvals.CheckError
 		}
 		_, err = fmt.Fprintf(&out, "\n")

--- a/libdctlint/lib.go
+++ b/libdctlint/lib.go
@@ -99,7 +99,7 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 	}
 
 	// Field checks provided by this file
-	if len(template.Version) == 0 {
+	if template.Version == 0 {
 		conf.tlog.Info().EmbedObject(internal.DCTL1006).Msg("")
 		exitVal |= exitvals.CheckInfo
 	}
@@ -149,7 +149,7 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 	// Pretty printing and/or inplace write output
 	if conf.prettyPrint || conf.inplace {
 		if conf.increment {
-			template.Version.Inc()
+			template.Version++
 		}
 		// Convert to json
 		marshaled, err := json.Marshal(template)

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 		flag.PrintDefaults()
 		_, _ = fmt.Fprintf(os.Stderr, "Warning. -inplace and -pretty will remove zero priority MX and SRV fields\n")
 		_, _ = fmt.Fprintf(os.Stderr, "You can find long DCTL explanations in wiki\n")
-		_, _ = fmt.Fprintf(os.Stderr, "e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1001\n")
+		_, _ = fmt.Fprintf(os.Stderr, "e.g., https://github.com/Domain-Connect/dc-template-linter/wiki/DCTL1003\n")
 	}
 	checkLogos := flag.Bool("logos", false, "check logo urls are reachable (requires network)")
 	cloudflare := flag.Bool("cloudflare", false, "use Cloudflare specific template rules")
@@ -83,7 +83,7 @@ func main() {
 		exitVal = conf.CheckTemplate(reader)
 	} else {
 		conf.SetInplace(*inplace).
-			SetTTL(*ttl).
+			SetTTL(uint32(*ttl)).
 			SetIncrement(*increment)
 
 		for _, arg := range flag.Args() {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const dcTemplateLinterVersion uint = 57
+const dcTemplateLinterVersion uint = 58


### PR DESCRIPTION
After this change numbers are always quoted after reformatting.  That is the only way to be somewhat consistent what is the representation format when %variables% need to be supported, and they need to be strings.

As a practical example, one could have the following in a template (and it would fail, but it's obvious why - see the hostname).

    "records": [
        {
            "type": "A",
            "host": "the-ttl-is-plain-number-this-is-ok",
            "ttl": 1800
        },
        {
            "type": "A",
            "host": "the-ttl-is-quoted-number-this-is-ok",
            "ttl": "8100"
        },
        {
            "type": "A",
            "host": "the-ttl-is-variable-this-is-ok",
            "ttl": "%varttl%"
        },
        {
            "type": "A",
            "host": "ttl-is-BROKEN-it-cannot-be-just-a-string",
            "ttl": "just-a-string"
        }
    ]

Reference: https://github.com/Domain-Connect/spec/pull/100