### PR TITLE
resolve #16, add CAA record support with basic RFC compliance check

### DIFF
--- a/libdctlint/record.go
+++ b/libdctlint/record.go
@@ -82,6 +82,14 @@ func (conf *Conf) checkRecord(
 			exitVal |= exitvals.CheckInfo
 		}
 
+	case "CAA":
+		if record.Host == "" {
+			rlog.Error().Str("key", "host").EmbedObject(internal.DCTL1013).Msg("")
+			exitVal |= exitvals.CheckError
+		}
+		// Validate CAA data string conforms to RFC 8659
+		exitVal |= checkCAA(record.Data, rlog)
+
 	case "MX":
 		if record.Host == "" {
 			rlog.Error().Str("key", "host").EmbedObject(internal.DCTL1013).Msg("")
@@ -330,6 +338,100 @@ func checkSPFRules(rules string, rlog zerolog.Logger) exitvals.CheckSeverity {
 			rlog.Error().Str("modifier", field).EmbedObject(internal.DCTL1017).Msg("")
 			exitVal |= exitvals.CheckError
 		}
+	}
+
+	return exitVal
+}
+
+func checkCAA(data string, rlog zerolog.Logger) exitvals.CheckSeverity {
+	exitVal := exitvals.CheckOK
+
+	// check data is not empty
+	d := strings.TrimSpace(data)
+	if d == "" {
+		rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+		return exitvals.CheckError
+	}
+	if isVariable(d) {
+		return exitvals.CheckOK
+	}
+
+	// Split into fields: expect at least flags, tag and value
+	fields := strings.Fields(d)
+	if len(fields) < 3 {
+		rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+		return exitvals.CheckError
+	}
+
+	// Validate flags (fields[0]) as unsigned integer 0..255
+	flags := fields[0]
+	if len(flags) == 0 {
+		rlog.Error().Str("flags", flags).EmbedObject(internal.DCTL1015).Msg("")
+		return exitvals.CheckError
+	}
+	var f uint64
+	for i := 0; i < len(flags); i++ {
+		if flags[i] < '0' || flags[i] > '9' {
+			rlog.Error().Str("flags", flags).EmbedObject(internal.DCTL1015).Msg("")
+			return exitvals.CheckError
+		}
+		f = f*10 + uint64(flags[i]-'0')
+		if f > 255 {
+			rlog.Error().Str("flags", flags).EmbedObject(internal.DCTL1015).Msg("")
+			return exitvals.CheckError
+		}
+	}
+
+	// Validate tag (fields[1])
+	tag := fields[1]
+	if tag == "" || strings.ToLower(tag) != tag || !regexp.MustCompile(`^[a-z0-9]+$`).MatchString(tag) {
+		rlog.Error().Str("tag", tag).EmbedObject(internal.DCTL1015).Msg("")
+		exitVal |= exitvals.CheckError
+	}
+
+	// Extract value as remaining fields
+	valueParts := fields[2:]
+	if len(valueParts) == 0 {
+		rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+		return exitvals.CheckError
+	}
+	value := strings.Join(valueParts, " ")
+
+	// Value must be wrapped in double quotes; reject if not
+	if !(len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"') {
+		rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+		exitVal |= exitvals.CheckError
+		return exitVal
+	}
+	value = strings.TrimSpace(value[1 : len(value)-1])
+
+	// Validate value not empty
+	if value == "" {
+		rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+		exitVal |= exitvals.CheckError
+		return exitVal
+	}
+
+	// Minimal semantic checks for common tags
+	switch tag {
+	case "issue", "issuewild":
+		// Allow wildcard '*' or a domain, optionally followed by parameters after ';'
+		main := value
+		if i := strings.IndexByte(main, ';'); i != -1 {
+			main = strings.TrimSpace(main[:i])
+		}
+		if main == "" {
+			rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+			exitVal |= exitvals.CheckError
+		}
+	case "iodef":
+		v := strings.ToLower(value)
+		if !(strings.HasPrefix(v, "mailto:") || strings.HasPrefix(v, "http://") || strings.HasPrefix(v, "https://")) {
+			rlog.Error().Str("data", data).EmbedObject(internal.DCTL1015).Msg("")
+			exitVal |= exitvals.CheckError
+		}
+	default:
+		// Unknown tags are allowed by RFC but must be lowercase token; already validated.
 	}
 
 	return exitVal


### PR DESCRIPTION
Adds support for CAA records to resolve issue #16.

Includes a parsing function to validate that the data portion of the record conforms to RFC8659 when static non-templated values are specified.

When given CAA records with invalid static data content or non-RFC conformant values it will error,

```
# flags > 255
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:05:11+10:00 ERR code=DCTL1015 dctl_note="invalid value" flags=256 groupid= record=2 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# flags less than 0
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:05:23+10:00 ERR code=DCTL1015 dctl_note="invalid value" flags=-1 groupid= record=2 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# invalid tag format
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:26:46+10:00 ERR code=DCTL1015 dctl_note="invalid value" groupid= record=1 tag=Issue template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates % 

# unsupport iodef URL type
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:05:46+10:00 ERR code=DCTL1015 data="128 iodef \"mongodb://mongo\"" dctl_note="invalid value" groupid= record=2 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# invalid iodef URL
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:06:32+10:00 ERR code=DCTL1015 data="0 iodef \"asdf\"" dctl_note="invalid value" groupid= record=1 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# invalid iodef URL
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:06:40+10:00 ERR code=DCTL1015 data="0 iodef \"asdf.com\"" dctl_note="invalid value" groupid= record=1 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# empty value
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:06:28+10:00 ERR code=DCTL1015 data="0 iodef \"\"" dctl_note="invalid value" groupid= record=1 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# empty value
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:07:19+10:00 ERR code=DCTL1015 data="0 issue \"\"" dctl_note="invalid value" groupid= record=1 template=goodroots.work.caa_management.json type=CAA
2025-08-20T16:07:19+10:00 ERR code=DCTL1015 data="128 issuewild \"\"" dctl_note="invalid value" groupid= record=2 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %

# missing one or more double quotes around value string
user@box domain-connect-templates % dc-template-linter goodroots.work.caa_management.json
2025-08-20T16:07:32+10:00 ERR code=DCTL1015 data="0 issue letsencrypt.org\"" dctl_note="invalid value" groupid= record=1 template=goodroots.work.caa_management.json type=CAA
2025-08-20T16:07:32+10:00 ERR code=DCTL1015 data="128 issuewild letsencrypt.org\"" dctl_note="invalid value" groupid= record=2 template=goodroots.work.caa_management.json type=CAA
user@box domain-connect-templates %
```