### PR TITLE
Cross reference linter code using ai with the spec and schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md - Domain Connect Template Linter
+
+## Project Overview
+
+This is a **Go** project that provides a command-line tool for validating Domain Connect templates.
+
+Domain Connect is an open standard that simplifies the process of connecting domain names to services by allowing Service Providers to automatically configure DNS settings through templates. This linter validates these templates against the official Domain Connect specification.
+
+## Language and Build
+
+- **Language**: Go (version 1.24.0)
+- **Module**: `github.com/Domain-Connect/dc-template-linter`
+- **Build**: Standard Go build (`go build`, `go install`)
+
+## Code Style
+
+All `.go` source files **must** be formatted using:
+
+```bash
+gofmt -s -w <file.go>
+```
+
+This ensures consistent code formatting across the project. The `-s` flag simplifies code, and `-w` writes the result back to the file.
+
+## Key Dependencies
+
+- `github.com/go-playground/validator/v10` - JSON struct validation
+- `github.com/rs/zerolog` - Structured logging
+- `github.com/cespare/xxhash/v2` - Hashing for duplicate detection
+- `github.com/THREATINT/go-net` - Network utilities
+
+## Project Structure
+
+```
+.
+├── main.go                 # CLI entry point
+├── go.mod, go.sum          # Go module files
+├── internal/               # Internal packages
+│   ├── dctl.go            # Domain Connect template lint definitions
+│   ├── json.go            # JSON utilities
+│   ├── utils.go           # General utilities
+│   ├── version.go         # Version information
+│   └── zerolog.go         # Logging setup
+├── libdctlint/             # Core linting library
+│   ├── lib.go             # Main linting logic
+│   ├── config.go          # Configuration structures
+│   ├── record.go          # DNS record validation
+│   ├── duplicates.go      # Duplicate detection
+│   ├── templatevar.go     # Template variable handling
+│   └── underscores.go     # Underscore validation
+├── exitvals/               # Exit value definitions
+│   └── exitvalues.go
+└── README.md
+```
+
+## Domain Connect Specification
+
+Template validation in this project is downstream from the official Domain Connect specification. The authoritative sources are:
+
+### Template Schema
+- **URL**: https://raw.githubusercontent.com/Domain-Connect/spec/refs/tags/draft-ietf-dconn-domainconnect-01/template.schema
+- **Format**: JSON Schema (Draft 07)
+- **Defines**: The complete structure of a Domain Connect template including:
+  - Provider and service identifiers (providerId, serviceId)
+  - Template metadata (providerName, serviceName, version, logoUrl, description)
+  - DNS records (A, AAAA, CNAME, NS, TXT, MX, SPFM, SRV, REDIR301, REDIR302, APEXCNAME)
+  - Template variables (values surrounded by %)
+  - Security settings (syncBlock, syncRedirectDomain, syncPubKeyDomain, warnPhishing)
+  - Multi-instance and shared template support
+
+### Specification Document
+- **URL**: https://raw.githubusercontent.com/Domain-Connect/spec/refs/heads/master/Domain%20Connect%20Spec%20Draft.adoc
+- **Format**: AsciiDoc
+- **Version**: 2.3 (Revision 67)
+- **Covers**:
+  - DNS Provider discovery via `_domainconnect` TXT records
+  - Synchronous flow (immediate DNS changes via web UI)
+  - Asynchronous OAuth flow (API-based changes)
+  - Template structure and record types
+  - Security considerations (signing, phishing warnings)
+  - Conflict detection and resolution
+
+## Important Implementation Notes
+
+1. **Template Validation**: The linter validates templates against the JSON schema and performs additional checks like:
+   - Duplicate record detection
+   - Underscore validation in hostnames
+   - Variable syntax validation
+   - Logo URL reachability (optional, with `-logos` flag)
+   - TTL validation
+
+2. **Exit Codes**: The tool uses bitfield exit codes defined in `exitvals/exitvalues.go`:
+   - `CheckOK` (0) - No issues
+   - `CheckFatal` (1) - Fatal errors
+   - `CheckError` (2) - Errors
+   - `CheckWarn` (4) - Warnings
+   - `CheckInfo` (8) - Informational messages
+
+3. **Cloudflare Mode**: The `-cloudflare` flag enables Cloudflare-specific template rules.
+
+4. **Pretty Printing**: The `-pretty` and `-inplace` flags can reformat template JSON (note: removes zero-priority MX and SRV fields).
+
+## Related Projects
+
+- **Templates Repository**: https://github.com/Domain-Connect/Templates.git - Public template repository
+- **Specification**: https://github.com/Domain-Connect/spec - Official specification
+- **Domain Connect Project**: https://www.domainconnect.org
+
+## Testing
+
+Run the linter against templates:
+```bash
+# Install
+go install github.com/Domain-Connect/dc-template-linter@latest
+
+# Validate templates
+dc-template-linter ./Templates/*.json
+
+# Check logo URLs
+dc-template-linter -logos ./Templates/*.json
+```
+
+## Contact
+
+Questions about this tool can be sent to <domain-connect@cloudflare.com>

--- a/internal/dctl.go
+++ b/internal/dctl.go
@@ -64,6 +64,7 @@ const (
 	DCTL1034 DCTL = 1034
 	DCTL1035 DCTL = 1035
 	DCTL1036 DCTL = 1036
+	DCTL1037 DCTL = 1037
 
 	DCTL5000 DCTL = 5000
 	DCTL5001 DCTL = 5001
@@ -130,6 +131,7 @@ var dctlToString = map[DCTL]string{
 	DCTL1034: "address record must point to a valid IP or a variable",
 	DCTL1035: "A record points to IPv6 address",
 	DCTL1036: "AAAA record points to IPv4 address",
+	DCTL1037: "hostRequired template should be combined with NS or CNAME record that uses host @ or empty",
 
 	// cloudflare messages
 	DCTL5000: "syncBlock is not supported",
@@ -196,6 +198,7 @@ var dctlLevel = map[DCTL]zerolog.Level{
 	DCTL1034: zerolog.ErrorLevel,
 	DCTL1035: zerolog.ErrorLevel,
 	DCTL1036: zerolog.ErrorLevel,
+	DCTL1037: zerolog.InfoLevel,
 
 	// cloudflare messages
 	DCTL5000: zerolog.ErrorLevel,

--- a/internal/dctl.go
+++ b/internal/dctl.go
@@ -65,6 +65,7 @@ const (
 	DCTL1035 DCTL = 1035
 	DCTL1036 DCTL = 1036
 	DCTL1037 DCTL = 1037
+	DCTL1038 DCTL = 1038
 
 	DCTL5000 DCTL = 5000
 	DCTL5001 DCTL = 5001
@@ -132,6 +133,7 @@ var dctlToString = map[DCTL]string{
 	DCTL1035: "A record points to IPv6 address",
 	DCTL1036: "AAAA record points to IPv4 address",
 	DCTL1037: "hostRequired template should be combined with NS or CNAME record that uses host @ or empty",
+	DCTL1038: "APEXCNAME and REDIRxxx records are not widely supported",
 
 	// cloudflare messages
 	DCTL5000: "syncBlock is not supported",
@@ -199,6 +201,7 @@ var dctlLevel = map[DCTL]zerolog.Level{
 	DCTL1035: zerolog.ErrorLevel,
 	DCTL1036: zerolog.ErrorLevel,
 	DCTL1037: zerolog.InfoLevel,
+	DCTL1038: zerolog.InfoLevel,
 
 	// cloudflare messages
 	DCTL5000: zerolog.ErrorLevel,

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const ProjectVersion uint = 110
+const ProjectVersion uint = 111

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const ProjectVersion uint = 109
+const ProjectVersion uint = 110

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,3 +1,3 @@
 package internal
 
-const ProjectVersion uint = 108
+const ProjectVersion uint = 109

--- a/libdctlint/lib.go
+++ b/libdctlint/lib.go
@@ -32,7 +32,7 @@ const (
 
 // ProjectVersion returns the dc-template-linter project version number.
 func ProjectVersion() uint {
-        return uint(internal.ProjectVersion)
+	return uint(internal.ProjectVersion)
 }
 
 // captureWriter is a zerolog-compatible io.Writer that parses each JSON log
@@ -265,6 +265,20 @@ func (conf *Conf) checkTemplate(template internal.Template) exitvals.CheckSeveri
 	} else {
 		if _, isEmpty := groupIdTrack[""]; isEmpty {
 			exitVal |= conf.emit(conf.tlog, internal.DCTL1032, nil)
+		}
+	}
+
+	// Check hostRequired constraint: must have NS or CNAME record with host @ or empty
+	if template.HostRequired {
+		hasRequiredRecord := false
+		for _, record := range template.Records {
+			if (record.Type == "NS" || record.Type == "CNAME") && (record.Host == "@" || record.Host == "") {
+				hasRequiredRecord = true
+				break
+			}
+		}
+		if !hasRequiredRecord {
+			exitVal |= conf.emit(conf.tlog, internal.DCTL1037, nil)
 		}
 	}
 

--- a/libdctlint/record.go
+++ b/libdctlint/record.go
@@ -167,12 +167,20 @@ func (conf *Conf) checkRecord(
 		if conf.cloudflare {
 			exitVal |= conf.emit(rlog, internal.DCTL5009, nil)
 		}
+		if record.PointsTo == "" {
+			exitVal |= conf.emit(rlog, internal.DCTL1013, func(e *zerolog.Event) *zerolog.Event {
+				return e.Str("key", "pointsTo")
+			})
+		}
 
 	case "REDIR301", "REDIR302":
 		if record.Target == "" {
 			exitVal |= conf.emit(rlog, internal.DCTL1013, func(e *zerolog.Event) *zerolog.Event {
 				return e.Str("key", "target")
 			})
+		}
+		if record.Host != "" {
+			exitVal |= targetCheck(conf, record, "target", rlog)
 		}
 	default:
 		exitVal |= conf.emit(rlog, internal.DCTL1016, nil)
@@ -269,7 +277,7 @@ func isInvalidProtocol(proto string) bool {
 
 func requiresTTL(recordType string) bool {
 	switch recordType {
-	case strCNAME, "NS", "A", "AAAA", "TXT", "MX", "SRV":
+	case strCNAME, "NS", "A", "AAAA", "TXT", "MX", "SRV", "APEXCNAME":
 		return true
 	}
 	return false

--- a/libdctlint/record.go
+++ b/libdctlint/record.go
@@ -166,6 +166,8 @@ func (conf *Conf) checkRecord(
 	case "APEXCNAME":
 		if conf.cloudflare {
 			exitVal |= conf.emit(rlog, internal.DCTL5009, nil)
+		} else {
+			exitVal |= conf.emit(rlog, internal.DCTL1038, nil)
 		}
 		if record.PointsTo == "" {
 			exitVal |= conf.emit(rlog, internal.DCTL1013, func(e *zerolog.Event) *zerolog.Event {
@@ -174,6 +176,7 @@ func (conf *Conf) checkRecord(
 		}
 
 	case "REDIR301", "REDIR302":
+		exitVal |= conf.emit(rlog, internal.DCTL1038, nil)
 		if record.Target == "" {
 			exitVal |= conf.emit(rlog, internal.DCTL1013, func(e *zerolog.Event) *zerolog.Event {
 				return e.Str("key", "target")


### PR DESCRIPTION
There are two changes in this review. The agents.md addition is pretty straightforward. Code update is a bit more interesting. What do we think is the _Check hostRequired constraint: must have NS or CNAME record with host @ or empty_ linting correct?

* e2061ff validate with Domain Connect spec and template.schema
* 50c5f79 docs: add AGENTS.md file to guide AI

Review-required-from: @pawel-kow 